### PR TITLE
Debian 10 (buster) reaching end-of-life

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["10", "11", "12", "trixie"]
+        version: ["11", "12", "trixie"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        version: ["10", "11", "12", "trixie"]
+        version: ["11", "12", "trixie"]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Supported Debian versions:
 * `13` - Trixie
 * `12` - Bookworm
 * `11` - Bullseye
-* `10` - Buster
 
 ## Available Images
 
@@ -19,7 +18,7 @@ and are automatically rebuilt once a week.
 * `ghcr.io/hifis-net/debian-systemd:trixie`
 * `ghcr.io/hifis-net/debian-systemd:12`
 * `ghcr.io/hifis-net/debian-systemd:11`
-* `ghcr.io/hifis-net/debian-systemd:10`
+* `ghcr.io/hifis-net/debian-systemd:10` (EOL)
 
 ## How to Use
 


### PR DESCRIPTION
> June 15th, 2024
>
>The Debian Long Term Support (LTS) Team hereby announces that Debian 10 buster support will reach its end-of-life on June 30, 2024, nearly five years after its initial release on July 6th, 2019.

See <https://www.debian.org/News/2024/20240615>